### PR TITLE
Optimized

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -3,51 +3,72 @@
 //! Common code
 
 use half::f16;
+use vapoursynth::component::Component;
 
-// Conversion functions to and from f64
+// Conversion trait to and from f64
 
-macro_rules! int_to_f64 {
-    ($($fname:ident<$int:ty>($op:tt $n:literal);)*) => {
-        $(
-            #[inline]
-            pub fn $fname(n: $int) -> f64 { ((n as u64) $op $n) as f64 }
-        )*
-    };
+// This is a weird name...
+pub trait F64Convertible: Sized + Copy + Component {
+    fn to_f64(self) -> f64;
+    fn from_f64(n: f64) -> Self;
 }
 
-macro_rules! f64_to_int {
-    ($($fname:ident<$int:ty>($op:tt $n:literal);)*) => {
-        $(
-            #[inline]
-            pub fn $fname(n: f64) -> $int { (n as $int) $op $n }
-        )*
-    };
+impl F64Convertible for u8 {
+    #[inline]
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+
+    #[inline]
+    fn from_f64(n: f64) -> Self {
+        n as u8
+    }
 }
 
-int_to_f64! {
-    u8_to_f64<u8>(<< 0);
-    u10_to_f64<u16>(<< 4);
-    u12_to_f64<u16>(<< 2);
-    u16_to_f64<u16>(<< 0);
-    u32_to_f64<u32>(<< 0);
+impl F64Convertible for u16 {
+    #[inline]
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+
+    #[inline]
+    fn from_f64(n: f64) -> Self {
+        n as u16
+    }
 }
 
-f64_to_int! {
-    f64_to_u8<u8>(>> 0);
-    f64_to_u10<u16>(>> 4);
-    f64_to_u12<u16>(>> 2);
-    f64_to_u16<u16>(>> 0);
-    f64_to_u32<u32>(>> 0);
+impl F64Convertible for u32 {
+    #[inline]
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+
+    #[inline]
+    fn from_f64(n: f64) -> Self {
+        n as u32
+    }
 }
 
-#[inline]
-pub fn f32_to_f64(n: f32) -> f64 { n as f64 }
+impl F64Convertible for f16 {
+    #[inline]
+    fn to_f64(self) -> f64 {
+        self.to_f64()
+    }
+    
+    #[inline]
+    fn from_f64(n: f64) -> Self {
+        f16::from_f64(n)
+    }
+}
 
-#[inline]
-pub fn f64_to_f32(n: f64) -> f32 { n as f32 }
+impl F64Convertible for f32 {
+    #[inline]
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
 
-#[inline]
-pub fn f16_to_f64(n: f16) -> f64 { n.to_f64() }
-
-#[inline]
-pub fn f64_to_f16(n: f64) -> f16 { f16::from_f64(n) }
+    #[inline]
+    fn from_f64(n: f64) -> Self {
+        n as f32
+    }
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -16,10 +16,10 @@ macro_rules! int_to_f64 {
 }
 
 macro_rules! f64_to_int {
-    ($($fname:ident<$int:ty>;)*) => {
+    ($($fname:ident<$int:ty>($op:tt $n:literal);)*) => {
         $(
             #[inline]
-            pub fn $fname(n: f64) -> $int { n as $int }
+            pub fn $fname(n: f64) -> $int { (n as $int) $op $n }
         )*
     };
 }
@@ -33,9 +33,11 @@ int_to_f64! {
 }
 
 f64_to_int! {
-    f64_to_u8<u8>;
-    f64_to_u16<u16>;
-    f64_to_u32<u32>;
+    f64_to_u8<u8>(>> 0);
+    f64_to_u10<u16>(>> 4);
+    f64_to_u12<u16>(>> 2);
+    f64_to_u16<u16>(>> 0);
+    f64_to_u32<u32>(>> 0);
 }
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,25 +75,18 @@ make_filter_function! {
         _core: CoreRef<'core>,
         clips: ValueIter<'_, 'core, Node<'core>>,
         preset: Option<i64>,
-        multipliers: Option<ValueIter<'_, 'core, f64>>
     ) -> Result<Option<Box<dyn Filter<'core> + 'core>>, Error> {
         let clips = clips.collect::<Vec<_>>();
         check_clips(&clips)?;
 
         let input_depth = property!(clips[0].info().format).bits_per_sample();
         if input_depth != 8 && input_depth != 10 && input_depth != 12 && input_depth != 16 && input_depth != 32 {
-            bail!("Input depth can only be 8, 10, 12, 16 or 32")
+            bail!("Input depth can only be 8, 10, 12, 16 or 32");
         }
 
-        let multipliers = match multipliers {
-            Some(multipliers) => match &multipliers.collect::<Box<_>>()[..] {
-                &[i, p, b] => [i, p, b],
-                _ => bail!("Three parameters must be given for multipliers, in the form multipliers=[I, P, B]"),
-            },
-            _ => match preset {
-                Some(1) => [1.82, 1.3, 1.0], // x264 / 5
-                _ => [1.0, 1.0, 1.0], // balanced
-            },
+        let multipliers = match preset {
+            Some(1) => [1.82, 1.3, 1.0], // x264 / 5
+            _ => [1.0, 1.0, 1.0], // balanced
         };
 
         Ok(Some(Box::new(Mean { clips, multipliers })))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@ make_filter_function! {
         check_clips(&clips)?;
 
         let input_depth = property!(clips[0].info().format).bits_per_sample();
-        if input_depth != 8 && input_depth != 10 && input_depth != 12 && input_depth != 16 && input_depth != 32 {
-            bail!("Input depth can only be 8, 10, 12, 16 or 32");
+        if input_depth < 8 || input_depth > 32 {
+            bail!("Input depth can only be between 8 and 32");
         }
 
         let multipliers = match preset {

--- a/src/mean.rs
+++ b/src/mean.rs
@@ -1,13 +1,13 @@
 // Copyright (c) EoE & Nephren 2020. All rights reserved.
 
-use crate::common::*;
-use crate::{property, PLUGIN_NAME};
 use failure::{bail, format_err, Error};
 use half::f16;
 use vapoursynth::core::CoreRef;
 use vapoursynth::plugins::{Filter, FrameContext};
 use vapoursynth::prelude::*;
 use vapoursynth::video_info::VideoInfo;
+use crate::{property, PLUGIN_NAME};
+use crate::common::*;
 
 macro_rules! mean {
     ($($fname:ident<$depth:ty>($depth_to_f64:path, $f64_to_depth:path);)*) => {
@@ -17,10 +17,10 @@ macro_rules! mean {
                     .iter()
                     .map(|f| f.props().get::<&'_ [u8]>("_PictType").unwrap_or(b"U")[0])
                     .map(|p| match p {
-                        b'I' | b'i' => { self.multipliers[0] },
-                        b'P' | b'p' => { self.multipliers[1] },
-                        b'B' => { self.multipliers[2] },
-                        _ => { 1.0 },
+                        b'I' | b'i' => self.multipliers[0],
+                        b'P' | b'p' => self.multipliers[1],
+                        b'B' => self.multipliers[2],
+                        _ => 1.0,
                     })
                     .collect();
 

--- a/src/mean.rs
+++ b/src/mean.rs
@@ -80,8 +80,8 @@ pub struct Mean<'core> {
 impl<'core> Mean<'core> {
     mean! {
         mean_u8<u8>(u8_to_f64, f64_to_u8);
-        mean_u10<u16>(u10_to_f64, f64_to_u16);
-        mean_u12<u16>(u12_to_f64, f64_to_u16);
+        mean_u10<u16>(u10_to_f64, f64_to_u10);
+        mean_u12<u16>(u12_to_f64, f64_to_u12);
         mean_u16<u16>(u16_to_f64, f64_to_u16);
         mean_u32<u32>(u32_to_f64, f64_to_u32);
 

--- a/src/mean.rs
+++ b/src/mean.rs
@@ -12,30 +12,6 @@ use vapoursynth::video_info::VideoInfo;
 macro_rules! mean {
     ($($fname:ident<$depth:ty>($depth_to_f64:path, $f64_to_depth:path);)*) => {
         $(
-<<<<<<< HEAD
-            pub fn $fname(&self, out_frame: &mut FrameRefMut, src_frames: &[FrameRef]) {
-                // `out_frame` has the same format as the source clips.
-                let format = out_frame.format();
-                let weights = src_frames.iter()
-                    .map(|f| f.props().get::<&'_ [u8]>("_PictType").unwrap_or(b"U")[0])
-                    .map(|p| match p {
-                        b'I' | b'i' => self.multipliers[0],
-                        b'P' | b'p' => self.multipliers[1],
-                        b'B' => self.multipliers[2],
-                        _ => 1.0,
-                    })
-                    .collect::<Vec<_>>();
-        
-                let multiplier = 1.0 / weights.iter().sum::<f64>();
-        
-                for plane in 0..format.plane_count() {
-                    for row in 0..format.plane_count() {
-                        let src_rows = src_frames.iter().map(|f| f.plane_row::<$depth>(plane, row)).collect::<Vec<_>>();
-                        let out_row = out_frame.plane_row_mut::<$depth>(plane, row);
-                        for ((out_pixel, src_pixels), &weight) in out_row.iter_mut().zip(src_rows.iter()).zip(weights.iter()) {
-                            let weighted_sum = src_pixels.iter().map(|&p| $depth_to_f64(p) * weight).sum::<f64>();
-                            unsafe { std::ptr::write(out_pixel, $f64_to_depth(weighted_sum * multiplier)); }
-=======
             pub fn $fname(&self, frame: &mut FrameRefMut, src_clips: &[FrameRef]) {
                 let weights: Vec<_> = src_clips
                     .iter()
@@ -59,12 +35,11 @@ macro_rules! mean {
                         for (i, pixel) in frame.plane_row_mut::<$depth>(plane, row).iter_mut().enumerate() {
                             let weighted_sum: f64 = src_rows
                                 .iter()
-                                .map(|f| $depth_in_to_f64(f[i]))
+                                .map(|f| $depth_to_f64(f[i]))
                                 .zip(weights.iter())
                                 .map(|(p, w)| p * w)
                                 .sum();
-                            unsafe { std::ptr::write(pixel, $f64_to_depth_out(weighted_sum * multiplier)) }
->>>>>>> 2415fad61e2d332a80706d104af967afeaa565b7
+                            unsafe { std::ptr::write(pixel, $f64_to_depth(weighted_sum * multiplier)) }
                         }
                     }
                 }


### PR DESCRIPTION
Given that this branch has now implemented 8..32 bit input via f22ee147d24a6a2514d85ce6f06840f89e34283b, and builds/runs without issue, I see no reason to not merge this to master, and then continue to use this branch for more optimised development tests. Then we can release a 0.3.0 with the updated API which should (hopefully) not change from now on.

With regards to direct `mutlipliers` access removal through the api via 89cdc8ad823e41665aea9c45c5e3ab8d4bdc573f, there are few reasons for the user to specify their own weights, so I'm happy for this to be merged too.